### PR TITLE
fix: Avoid error when files are changed during tar

### DIFF
--- a/lib/commands/state.ts
+++ b/lib/commands/state.ts
@@ -12,7 +12,13 @@ export function saveState(): Cypress.Chainable<string> {
 	const snapshot = Math.random().toString(36).substring(7)
 
 	runCommand(`rm /var/www/html/data-${snapshot}.tar`, { failOnNonZeroExit: false })
-	runCommand(`tar cf /var/www/html/data-${snapshot}.tar ./data`)
+	// The instance keeps writing into ./data while we archive it (e.g. the
+	// nextcloud.log, caches, session files), so a file can change mid-read and
+	// GNU tar exits 1 with "file changed as we read it". That is harmless for a
+	// test-state snapshot: silence the warning and treat exit 1 (benign,
+	// "some files differ") as success while still failing on a real error
+	// (exit 2, fatal).
+	runCommand(`tar --warning=no-file-changed -cf /var/www/html/data-${snapshot}.tar ./data || [ $? -eq 1 ]`)
 
 	cy.log(`Created snapshot ${snapshot}`)
 


### PR DESCRIPTION
Our own runners are painfully slow. This lead to race-conditions that must be handled. This PR fixes one of those for the `saveState` function, that creates a tar file and is being run as `beforeEach` during some tests in cypress.

Output of such a failed run:

```
  3 passing (2m)
  1 failing

  1) files_sharing: Public share - downloading files
       folder share
         "before all" hook for "Can download all files":
     CypressError: `cy.exec('docker exec --user www-data --workdir /var/www/html  nextcloud-e2e-test-server_server bash -c "tar cf /var/www/html/data-la3dmc.tar ./data"')` failed because the command exited with a non-zero code.

Pass `{failOnNonZeroExit: false}` to ignore exit code failures.

Information about the failure:
Code: 1

Stderr:
tar: ./data: file changed as we read it

https://on.cypress.io/exec

Because this error occurred during a `before all` hook we are skipping the remaining tests in the current suite: `folder share`
      at <unknown> (http://localhost:8042/__cypress/runner/cypress_runner.js:121543:77)
      at tryCatcher (http://localhost:8042/__cypress/runner/cypress_runner.js:1777:23)
      at Promise._settlePromiseFromHandler (http://localhost:8042/__cypress/runner/cypress_runner.js:1489:31)
      at Promise._settlePromise (http://localhost:8042/__cypress/runner/cypress_runner.js:1546:18)
      at Promise._settlePromise0 (http://localhost:8042/__cypress/runner/cypress_runner.js:1591:10)
      at Promise._settlePromises (http://localhost:8042/__cypress/runner/cypress_runner.js:1671:18)
      at _drainQueueStep (http://localhost:8042/__cypress/runner/cypress_runner.js:2377:12)
      at _drainQueue (http://localhost:8042/__cypress/runner/cypress_runner.js:2370:9)
      at Async._drainQueues (http://localhost:8042/__cypress/runner/cypress_runner.js:2386:5)
      at Async.drainQueues (http://localhost:8042/__cypress/runner/cypress_runner.js:2256:14)
```

To handle that error, tar is now being configured to ignore those issues. As the exit code is still `1`, we have to modify that to treat it as `0` to keep cypress running in that case and not aborting the whole test suite.

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
