### PR TITLE
fix(docker): list the apps after `apps-writable` is a known apps path

### DIFF
--- a/lib/docker.ts
+++ b/lib/docker.ts
@@ -261,10 +261,6 @@ export async function configureNextcloud(apps = ['viewer'], vendoredBranch?: str
 	}
 	console.log('│  └─ OK !')
 
-	// Build app list
-	const { stdout: json } = await runOcc(['app:list', '--output', 'json'], { container })
-	const applist = JSON.parse(json)
-
 	console.log('├─ Using "apps-writable" folder for mounted apps')
 	await runExec(['mkdir', '-p', '/var/www/html/apps-writable'], { container })
 	await runExec(['chown', 'www-data:www-data', '/var/www/html/apps-writable'], { container, user: 'root' })
@@ -287,6 +283,10 @@ export async function configureNextcloud(apps = ['viewer'], vendoredBranch?: str
 	stream.entry({ name: 'apps.config.php' }, appsConfig)
 	stream.finalize()
 	await container.putArchive(stream, { path: '/var/www/html/config' })
+
+	// Build app list, only now that "apps-writable" is a known apps path so that mounted apps show up
+	const { stdout: json } = await runOcc(['app:list', '--output', 'json'], { container })
+	const applist = JSON.parse(json)
 
 	// Enable apps and give status
 	for (const app of apps) {


### PR DESCRIPTION
Rebased on the current `main` and reduced to what is left. #1061 already fixed the `chown` part independently, so only the app list ordering remains.

## Problem

`configureNextcloud()` fails as soon as an app is bind mounted into `apps-writable`, which `startNextcloud(branch, true)` does by default:

```
[cause]: { stdout: 'attendance already installed\n', stderr: '', exitCode: 1 }
```

`app:list` is queried *before* `apps.config.php` registers `apps-writable` as an apps path, so the mounted app is missing from the list. It is then not found in `shipped.json` either and ends up in the app store branch, where `app:install --force` exits non-zero with "already installed".

The repo's own test suite passes `mountApp: false`, so this is not covered by CI.

## Fix

Build the app list only after `apps.config.php` has been written. Four lines moved, no behaviour change for the non mounted case.

## Testing

* `npm run lint`, `npm run build`, `npx tsc --noEmit` clean
* `npm run test:node` 4/4 pass (unchanged behaviour, `mountApp: false`)
* Against a bind mounted app (`nextcloud/attendance`, `stable34`, macOS + Docker Desktop): `configureNextcloud` now completes and reports `attendance 1.42.0 enabled` instead of aborting. The same run also confirmed that with the named volume from #1061 the `mkdir` no longer needs to run as root, so that part of my original change is gone.
