### PR TITLE
fix(docker): install the composer dependencies of cloned shipped apps

### DIFF
--- a/lib/docker.ts
+++ b/lib/docker.ts
@@ -261,10 +261,6 @@ export async function configureNextcloud(apps = ['viewer'], vendoredBranch?: str
 	}
 	console.log('│  └─ OK !')
 
-	// Build app list
-	const { stdout: json } = await runOcc(['app:list', '--output', 'json'], { container })
-	const applist = JSON.parse(json)
-
 	console.log('├─ Using "apps-writable" folder for mounted apps')
 	await runExec(['mkdir', '-p', '/var/www/html/apps-writable'], { container })
 	await runExec(['chown', 'www-data:www-data', '/var/www/html/apps-writable'], { container, user: 'root' })
@@ -287,6 +283,10 @@ export async function configureNextcloud(apps = ['viewer'], vendoredBranch?: str
 	stream.entry({ name: 'apps.config.php' }, appsConfig)
 	stream.finalize()
 	await container.putArchive(stream, { path: '/var/www/html/config' })
+
+	// Build app list, only now that "apps-writable" is a known apps path so that mounted apps show up
+	const { stdout: json } = await runOcc(['app:list', '--output', 'json'], { container })
+	const applist = JSON.parse(json)
 
 	// Enable apps and give status
 	for (const app of apps) {

--- a/lib/docker.ts
+++ b/lib/docker.ts
@@ -17,6 +17,12 @@ import { User } from './User.ts'
 
 const SERVER_IMAGE = 'ghcr.io/nextcloud/continuous-integration-shallow-server'
 
+// The server image ships PHP but no Composer, so it is downloaded on demand
+const COMPOSER_VERSION = process.env.NEXTCLOUD_E2E_COMPOSER_VERSION || 'latest-stable'
+const COMPOSER_PHAR = '/tmp/composer.phar'
+/** `COMPOSER_HOME` used inside the server container, must be writable by `www-data` */
+const COMPOSER_HOME = '/tmp/composer-home'
+
 export const docker = new Docker({ socketPath: process.env.DOCKER_SOCKET ?? '/var/run/docker.sock' })
 
 // Store the container name, different names are used to prevent conflicts when testing multiple apps locally
@@ -230,6 +236,9 @@ function pullImage() {
 /**
  * Configure Nextcloud
  *
+ * Shipped apps that are missing from the server image are cloned and their Composer dependencies
+ * are installed. Set `NEXTCLOUD_E2E_COMPOSER_VERSION` to pin the Composer version used for that.
+ *
  * @param apps List of default apps to install (default is ['viewer'])
  * @param vendoredBranch The branch used for vendored apps, should match server (defaults to latest branch used for `startNextcloud` or fallsback to `master`)
  * @param container Optional server container to use (defaults to current container)
@@ -304,6 +313,7 @@ export async function configureNextcloud(apps = ['viewer'], vendoredBranch?: str
 					['git', 'clone', '--depth=1', ...branchOption, `https://github.com/nextcloud/${encodeURIComponent(app)}.git`, `apps-writable/${app}`],
 					{ container, verbose: true },
 				)
+				await installComposerDependencies(app, container)
 				await runOcc(['app:enable', '--force', app], { container, verbose: true })
 			} else {
 				// try appstore
@@ -312,6 +322,58 @@ export async function configureNextcloud(apps = ['viewer'], vendoredBranch?: str
 		}
 	}
 	console.log('└─ Nextcloud is now ready to use 🎉')
+}
+
+/**
+ * Check whether a path exists inside the container
+ *
+ * @param path Absolute path to check
+ * @param container The server container to use
+ */
+async function pathExists(path: string, container: Container): Promise<boolean> {
+	const { exitCode } = await runExec(['test', '-e', path], { container, failOnError: false })
+	return exitCode === 0
+}
+
+/**
+ * Install the Composer dependencies of a cloned app
+ *
+ * A bare `git clone` is only usable as long as the app commits its dependencies. Since Nextcloud 34
+ * `notifications` does not, and `OC_App::registerAutoloading()` then fatals on the missing
+ * `vendor/autoload.php`. Scripts are run on purpose, apps like that one only assemble the prefixed
+ * copies of their dependencies (`lib/Vendor`) in `post-install-cmd`.
+ *
+ * @param app The app id, cloned to `apps-writable/<app>`
+ * @param container The server container to use
+ */
+async function installComposerDependencies(app: string, container: Container) {
+	const appPath = `/var/www/html/apps-writable/${app}`
+	if (!await pathExists(`${appPath}/composer.json`, container)) {
+		return
+	}
+
+	await ensureComposer(container)
+	console.log(`│  ├─ Running 'composer install' for ${app}…`)
+	await runExec(
+		['php', COMPOSER_PHAR, 'install', '--no-dev', '--no-interaction', '--no-progress', '--no-ansi'],
+		{ container, workingDir: appPath, env: [`COMPOSER_HOME=${COMPOSER_HOME}`] },
+	)
+	console.log('│  └─ Done')
+}
+
+/**
+ * Download the Composer binary into the container, unless it is already there
+ *
+ * @param container The server container to use
+ */
+async function ensureComposer(container: Container) {
+	if (await pathExists(COMPOSER_PHAR, container)) {
+		return
+	}
+
+	console.log(`│  ├─ Downloading Composer ${COMPOSER_VERSION} into the container…`)
+	const url = `https://getcomposer.org/download/${COMPOSER_VERSION}/composer.phar`
+	await runExec(['curl', '--silent', '--show-error', '--location', '--fail', '--output', COMPOSER_PHAR, url], { container })
 }
 
 /**
@@ -439,6 +501,10 @@ export interface RunExecOptions {
 	 * If true, the command's output will be printed to the console. Defaults to false.
 	 */
 	verbose: boolean
+	/**
+	 * Working directory to run the command in. Defaults to the Nextcloud root.
+	 */
+	workingDir: string
 }
 
 export type RunExecResult = {
@@ -457,10 +523,11 @@ export type RunExecResult = {
  * @param options.verbose - If true, the command's output will be printed to the console. Defaults to false.
  * @param options.env - Environment variables to set for the command. Defaults to an empty array.
  * @param options.failOnError - The command will throw an error if it exits with a non-zero exit code. Defaults to true.
+ * @param options.workingDir - Working directory to run the command in. Defaults to the Nextcloud root.
  */
 export async function runExec(
 	command: string | string[],
-	{ container, user = 'www-data', verbose = false, env = [], failOnError = true }: Partial<RunExecOptions> = {},
+	{ container, user = 'www-data', verbose = false, env = [], failOnError = true, workingDir }: Partial<RunExecOptions> = {},
 ): Promise<RunExecResult> {
 	container = container || getContainer()
 	const exec = await container.exec({
@@ -469,6 +536,7 @@ export async function runExec(
 		AttachStderr: true,
 		User: user,
 		Env: env,
+		WorkingDir: workingDir,
 	})
 
 	return new Promise<RunExecResult>((resolve, reject) => {

--- a/tests/docker.spec.ts
+++ b/tests/docker.spec.ts
@@ -11,7 +11,7 @@ describe('Docker: Pre-installation of apps', async () => {
 	before(async () => {
 		const ip = await startNextcloud('master', false, { forceRecreate: true, exposePort: 8088 })
 		await waitOnNextcloud(ip)
-		await configureNextcloud(['viewer', 'text', 'forms'])
+		await configureNextcloud(['viewer', 'text', 'forms', 'notifications'])
 	})
 
 	after(async () => {
@@ -39,6 +39,14 @@ describe('Docker: Pre-installation of apps', async () => {
 		await runExec(['file', '-f', 'apps-writable/forms/appinfo/info.xml'], { container })
 		const { enabled } = await getAppsList()
 		expect.equal('forms' in enabled, true, 'Forms app should be enabled')
+	})
+
+	await test('Additional apps: apps that do not commit their dependencies get them installed', async () => {
+		const container = getContainer()
+		// this must not throw
+		await runExec(['test', '-f', 'apps-writable/notifications/vendor/autoload.php'], { container })
+		const { enabled } = await getAppsList()
+		expect.equal('notifications' in enabled, true, 'Notifications app should be enabled')
 	})
 })
 


### PR DESCRIPTION
> [!NOTE]
> Stacked on #1063, so the first commit belongs to that PR. Please merge #1063 first, without it `configureNextcloud` aborts before it ever reaches this code path when an app is bind mounted.

Fixes #1059. Companion to nextcloud/notifications#3206, where @nickvergessen pointed at this spot in `lib/docker.ts` as the place to solve it.

## Problem

Shipped apps that are missing from the CI server image are installed with a plain `git clone`, which only works as long as the app commits its composer dependencies.

Since `stable34`, `nextcloud/notifications` no longer bundles them, but still ships a `composer/autoload.php` doing `require_once __DIR__ . '/../vendor/autoload.php'`, and `vendor/` is git ignored. `OC_App::registerAutoloading()` requires that file, so **every** request and every `occ` call dies:

```
Error: Failed opening required '/var/www/html/apps/notifications/composer/../vendor/autoload.php'
  … in /var/www/html/apps/notifications/composer/autoload.php:9
#0 /var/www/html/lib/private/legacy/OC_App.php(117): require_once()
#1 /var/www/html/lib/private/AppFramework/Bootstrap/Coordinator.php(78): OC_App::registerAutoloading()
```

On `stable33` the `composer/` directory did not exist yet, which is why this only surfaces when a suite moves to `stable34`. 0.4.0 and 0.5.0 are affected alike, the clone logic is unchanged between them.

## Fix

If a cloned app has a `composer.json`, run `composer install --no-dev` for it. The server image ships PHP but no composer, so `composer.phar` is downloaded into the container once. `NEXTCLOUD_E2E_COMPOSER_VERSION` pins the version for consumers who want that, the default is `latest-stable`.

Scripts are run on purpose. Apps like `notifications` only assemble the prefixed copies of their dependencies (`lib/Vendor/`, via `bamarni/composer-bin-plugin` plus `coenjacobs/mozart` in `post-install-cmd`) there, so skipping scripts would leave the app loadable but still broken for web push.

A failing install fails the setup, and the public API is unchanged.

An earlier revision of this PR probed the app's composer autoloader and, when the install failed, degraded to removing the cloned `composer/` directory. Both are gone after @susnux's review, see the discussion below.

## Alternatives considered

* **`composer install` on the host, result shipped in via `container.putArchive`** (the workaround by @theCalcaholic in nextcloud/notifications#3206). Works, but adds a host dependency on PHP and composer. Given on `ubuntu-latest`, not given for contributors running the suite locally. The in-container variant behaves the same on Linux runners and on macOS with Docker Desktop.
* **Only removing the cloned `composer/` directory** (my own workaround in #1059). Needs no toolchain at all, but `lib/Vendor/` stays absent, so anything touching web push logs `Class "OCA\Notifications\Vendor\Minishlink\WebPush\VAPID" not found`.
* **Installing such apps from the app store instead of cloning.** App store tarballs do ship `vendor/`, and it would remove this code path entirely. Rejected because it gives up matching the app to the server branch, which is the reason the clone exists.
* **Shipping composer in the CI server image.** Arguably the right layer, and I would happily drop the download if that lands in `continuous-integration-shallow-server`. Until then this keeps consumers working without an image change.
* **Verifying the downloaded `composer.phar` against its published checksum.** Left out: it is served from the same host over the same HTTPS connection, so it proves transfer integrity rather than authenticity, while the code deliberately executes third-party scripts from a fresh `git clone` moments later.

## Testing

* `npm ci`, `npx tsc --noEmit`, `npm run lint`, `npm run build` clean (lint: 0 errors, the 8 warnings are pre-existing in `lib/commands/*`)
* `npm run test:node` **4/4 pass**, with `notifications` added to the suite plus an assertion that its `vendor/autoload.php` exists and that the app is enabled

Running the install for every cloned app is cheap, measured in the server image after a `git clone --depth=1`:

| app | `composer install --no-dev` | autoloader afterwards | committed `composer/` |
| --- | --- | --- | --- |
| viewer | 0s, exit 0 | loads | untouched |
| text | 0s, exit 0 | loads | untouched |
| notifications | 22s, exit 0 | loads (was fatal before) | untouched |

End to end against a real `stable34` server, using [`nextcloud/attendance`](https://github.com/luflow/attendance) (the consumer from #1059) with this build linked in and its test server bumped `stable33` to `stable34`:

```
├─ stderr: Cloning into 'apps-writable/notifications'...
│  ├─ Downloading Composer latest-stable into the container…
│  ├─ Running 'composer install' for notifications…
│  └─ Done
├─ stdout: notifications 7.0.0-dev.1 enabled
├─ stdout: attendance 1.42.0 enabled
└─ Nextcloud is now ready to use 🎉
✅ Snapshot "init" created successfully!
```

Completeness checked in the container, not just "it boots":

```console
$ docker exec … ls /var/www/html/apps-writable/notifications/lib/Vendor | head -3
Base64Url
Brick
GuzzleHttp

$ docker exec -u www-data … php occ app:list | grep -E 'notifications|attendance'
  - attendance: 1.42.0
  - notifications: 7.0.0-dev.1

$ docker exec … sh -c "tail -c 4000 /var/www/html/data/nextcloud.log" | grep -ci vapid
0
```

## Not verified

* Linux runners, everything above ran on macOS with Docker Desktop.
* The full Playwright suite of the consuming app against `stable34`, only the server setup was exercised. Failures there would be NC33 to NC34 UI changes, unrelated to this.
* Apps other than `notifications` actually hitting the missing autoloader.
